### PR TITLE
Fix #1: Run server in port 3000

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "postAttachCommand": {
     "server": "yarn start"
   },
-  "forwardPorts": [3001],
+  "forwardPorts": [3000],
   "customizations": {
     "codespaces": {
       "openFiles": ["index.js", "package.json"]

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const app = express();
-const port = 3001;
+const port = 3000;
 
 app.get("/", (req, res) => {
   console.log(`${new Date()} ${req.method} ${req.path}`);


### PR DESCRIPTION
Fixes #1

Run server in port 3000

This PR was created with Copilot Workspace (v0.14). For more details, open the [Copilot Workspace session](https://copilot-workspace-dev.githubnext.com/osortega/simple-server/issues/1?shareId=d63b2164-3371-4a0f-9660-08902af039f6).