### PR TITLE
server: update port and add smoke tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const express = require("express");
 const patchHandler = require("./patchHandler");
 const app = express();
 
-const port = 824;
+const port = 1245;
 
 app.put("/silly2", (req, res) => {
   const sounds = ["🎺 tuba", "🥁 kazoo", "🎻 squeaky violin", "📯 vuvuzela", "🔔 cowbell"];

--- a/index.js
+++ b/index.js
@@ -101,4 +101,8 @@ const b = [1, 2, 3, 4, 5];
 
 app.use("/", patchHandler);
 
-app.listen(port, () => console.log(`Example app listening on port ${port}!`));
+if (require.main === module) {
+  app.listen(port, () => console.log(`Example app listening on port ${port}!`));
+}
+
+module.exports = { app, port };

--- a/index.test.js
+++ b/index.test.js
@@ -1,0 +1,56 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const http = require("node:http");
+
+const { app, port } = require("./index");
+
+function request(server, path, method = "GET") {
+  return new Promise((resolve, reject) => {
+    const address = server.address();
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port: address.port,
+        path,
+        method,
+      },
+      (res) => {
+        let body = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          body += chunk;
+        });
+        res.on("end", () => {
+          resolve({ statusCode: res.statusCode, body });
+        });
+      },
+    );
+
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+test("GET / shows the configured port", async () => {
+  const server = app.listen(0);
+
+  try {
+    const response = await request(server, "/");
+    assert.equal(response.statusCode, 200);
+    assert.match(response.body, new RegExp(`port ${port}`));
+  } finally {
+    server.close();
+  }
+});
+
+test("PATCH / is handled by the patch router", async () => {
+  const server = app.listen(0);
+
+  try {
+    const response = await request(server, "/", "PATCH");
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.body, "Patch");
+  } finally {
+    server.close();
+  }
+});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "nodemon index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Summary
- keep the server configured on port `1245`
- make `index.js` export the Express app and port while only listening when run directly
- replace the placeholder failing `npm test` script with lightweight Node smoke tests

## Why
- the session change updates the app to the requested port
- the repository previously had no meaningful passing validation because `npm test` intentionally failed
- exporting the app enables simple request-level tests without changing runtime behavior

## Validation
- `npm test`

## Notes for reviewers
- this PR includes the earlier port-change commit already present on the branch plus a follow-up commit that makes repository validation real and passing