### PR TITLE
server: update default port to 9384

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const express = require("express");
 const patchHandler = require("./patchHandler");
 const app = express();
 
-const port = 824;
+const port = 9384;
 
 app.put("/silly2", (req, res) => {
   const sounds = ["🎺 tuba", "🥁 kazoo", "🎻 squeaky violin", "📯 vuvuzela", "🔔 cowbell"];


### PR DESCRIPTION
## What changed
- updated the Express server's default port from `824` to `9384` in `index.js`
- kept the rendered homepage status text and startup log aligned automatically via the shared `port` constant

## Why
- the session request was to run the server on port `9384`

## Reviewer notes
- the branch diff is limited to this one port change
- `npm test` currently fails because the repository's existing test script is the placeholder `echo "Error: no test specified" && exit 1`; no additional validation scripts are defined in `package.json`